### PR TITLE
Fix notification scheduling

### DIFF
--- a/EverySo/AddEntryView.swift
+++ b/EverySo/AddEntryView.swift
@@ -92,6 +92,8 @@ struct AddEntryView: View {
                     if resetOnSave {
                         existing.lastReset = Date()
                         existing.resetCountdown()
+                    } else {
+                        existing.scheduleNotification()
                     }
                 } else {
                     let newEntry = CountdownEntry(
@@ -104,6 +106,7 @@ struct AddEntryView: View {
                     newEntry.notifyOnReady = notifyOnReady
                     newEntry.resetOnSave = resetOnSave
                     modelContext.insert(newEntry)
+                    newEntry.scheduleNotification()
                 }
                 do {
                     try modelContext.save()

--- a/EverySo/CountdownEntry.swift
+++ b/EverySo/CountdownEntry.swift
@@ -154,6 +154,9 @@ class CountdownEntry {
     /// Call this whenever the countdown's lastReset date or interval changes.
     /// For example, after resetting, editing interval, or creating a new CountdownEntry.
     func scheduleNotification() {
+        // Remove any existing notification for this countdown in case
+        // the schedule or notification preference changed.
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id.uuidString])
         guard notifyOnReady else { return }
         let triggerDate = nextAvailableDate
         guard triggerDate > Date() else { return }


### PR DESCRIPTION
## Summary
- ensure notifications are properly scheduled or removed when editing/adding entries
- add logic to reschedule notifications when preferences change

## Testing
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6f5c65048333871f0b8dea4944a2